### PR TITLE
Fix docker build for ARM based notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # cdk asset
 cdk.out

--- a/ecs_fargate_app/finch/backend.Dockerfile
+++ b/ecs_fargate_app/finch/backend.Dockerfile
@@ -1,5 +1,7 @@
+ARG PLATFORM="amd64"
+
 # Build stage
-FROM --platform=linux/amd64 node:18-alpine as build
+FROM --platform=linux/${PLATFORM} node:18-alpine as build
 
 WORKDIR /app
 
@@ -17,7 +19,7 @@ COPY backend/ .
 RUN npm run build
 
 # Production stage
-FROM --platform=linux/amd64 node:18-alpine
+FROM --platform=linux/${PLATFORM} node:18-alpine
 
 WORKDIR /app
 

--- a/ecs_fargate_app/finch/backend.dev.Dockerfile
+++ b/ecs_fargate_app/finch/backend.dev.Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=linux/amd64 node:18-alpine
+ARG PLATFORM="amd64"
+
+FROM --platform=linux/${PLATFORM} node:18-alpine
 
 WORKDIR /app
 

--- a/ecs_fargate_app/finch/frontend.Dockerfile
+++ b/ecs_fargate_app/finch/frontend.Dockerfile
@@ -1,5 +1,7 @@
+ARG PLATFORM="amd64"
+
 # Build stage
-FROM --platform=linux/amd64 node:18-alpine as build
+FROM --platform=linux/${PLATFORM} node:18-alpine as build
 
 WORKDIR /app
 
@@ -17,7 +19,7 @@ COPY frontend/ .
 RUN npm run build
 
 # Production stage
-FROM --platform=linux/amd64 nginx:alpine
+FROM --platform=linux/${PLATFORM} nginx:alpine
 
 # Copy built files
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/ecs_fargate_app/finch/frontend.dev.Dockerfile
+++ b/ecs_fargate_app/finch/frontend.dev.Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=linux/amd64 node:18-alpine
+ARG PLATFORM="amd64"
+
+FROM --platform=linux/${PLATFORM} node:18-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
*Issue #, if available:*
None created

*Description of changes:*
Fixes finch build for ARM Notebooks. If there is a ARM Notebook, both finch build as well as ECS Fargate use ARM. Otherwise AMD is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
