### PR TITLE
Add Brazilian Portuguese translations

### DIFF
--- a/ecs_fargate_app/backend/src/prompts/languages.ts
+++ b/ecs_fargate_app/backend/src/prompts/languages.ts
@@ -31,7 +31,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
     nativeName: 'Español'
   },
   {
-    code: 'pt',
+    code: 'pt_BR',
     name: 'Brazilian Portuguese',
     nativeName: 'Português Brasileiro'
   },

--- a/ecs_fargate_app/frontend/src/i18n/languages.ts
+++ b/ecs_fargate_app/frontend/src/i18n/languages.ts
@@ -36,7 +36,7 @@ export const SUPPORTED_LANGUAGES: LanguageDefinition[] = [
     nativeName: 'Español'
   },
     {
-    code: 'pt',
+    code: 'pt_BR',
     label: 'Brazilian Portuguese',
     nativeName: 'Português Brasileiro'
   }

--- a/ecs_fargate_app/frontend/src/i18n/strings.ts
+++ b/ecs_fargate_app/frontend/src/i18n/strings.ts
@@ -885,7 +885,7 @@ export const i18nStrings: Record<Language, I18nStrings> = {
       workloadIdInput: "Opcionalmente, ingrese un ID de carga de trabajo existente de Well-Architected Tool, o deje en blanco para crear uno nuevo.",
     }
   },
-    pt: {
+    pt_BR: {
     common: {
       loading: "Carregando",
       error: "Erro",

--- a/localization/README.md
+++ b/localization/README.md
@@ -3,16 +3,23 @@
 This guide explains how to add new language translations to the Well-Architected IaC Analyzer application. The application uses a centralized approach to manage language configurations, making it straightforward to add support for new languages.
 
 ## Table of Contents
-- [Overview](#overview)
-- [File Structure](#file-structure)
-- [Adding a New Language](#adding-a-new-language)
-  - [Step 1: Update Frontend Language Configuration](#step-1-update-frontend-language-configuration)
-  - [Step 2: Update Backend Language Configuration](#step-2-update-backend-language-configuration)
-  - [Step 3: Add Language Translations](#step-3-add-language-translations)
-  - [Step 4: Test Your Changes](#step-4-test-your-changes)
-  - [Step 5: Create a Pull Request](#step-5-create-a-pull-request)
-- [Translation Best Practices](#translation-best-practices)
-- [Common Issues](#common-issues)
+- [Internationalization (i18n) Guide](#internationalization-i18n-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [File Structure](#file-structure)
+    - [Frontend](#frontend)
+    - [Backend](#backend)
+  - [Adding a New Language](#adding-a-new-language)
+    - [Step 1: Update Frontend Language Configuration](#step-1-update-frontend-language-configuration)
+    - [Step 2: Update Backend Language Configuration](#step-2-update-backend-language-configuration)
+    - [Step 3: Add Language Translations](#step-3-add-language-translations)
+    - [Step 4: Test Your Changes](#step-4-test-your-changes)
+    - [Step 5: Create a Pull Request](#step-5-create-a-pull-request)
+  - [Translation Best Practices](#translation-best-practices)
+  - [Common Issues](#common-issues)
+    - [Missing Translations](#missing-translations)
+    - [Character Set Issues](#character-set-issues)
+    - [RTL Language Support](#rtl-language-support)
 
 ## Overview
 
@@ -22,6 +29,7 @@ Currently, the application supports:
 - English (en) - Default
 - Japanese (ja)
 - Spanish (es)
+- Brazilian Portuguese (pt-BR)
 
 ## File Structure
 


### PR DESCRIPTION
*Description of changes:*

- Brazilian Portuguese translation
- Used `pt_BR` as is the ISO 15897 but could be just `pt`, but decided to maintain the standard.

pt variants for reference:

```
    pt_BR: "Portuguese (Brazil)",
    pt_GW: "Portuguese (Guinea-Bissau)",
    pt_MZ: "Portuguese (Mozambique)",
    pt_PT: "Portuguese (Portugal)",
    pt: "Portuguese",
```
- Tested locally