### PR TITLE
Fix: Clear partial results warning when switching between work items

### DIFF
--- a/ecs_fargate_app/frontend/src/components/WellArchitectedAnalyzer.tsx
+++ b/ecs_fargate_app/frontend/src/components/WellArchitectedAnalyzer.tsx
@@ -650,10 +650,13 @@ export const WellArchitectedAnalyzer: React.FC<Props> = ({ onWorkItemsRefreshNee
       const lensAlias = lensAliasArn?.split('/')?.pop();
       let lensName = '';
 
-      // Reset risk summary when switching work items
+      // Reset states when switching work items
       setRiskSummary(null);
       setCreatedWorkloadId(undefined);
       setWorkloadId(undefined);
+      setShowPartialResultsWarning(false);
+      setPartialResultsError('');
+      setError('');
 
       // If lensAlias is provided, set it as active
       if (lensAlias) {
@@ -863,6 +866,10 @@ export const WellArchitectedAnalyzer: React.FC<Props> = ({ onWorkItemsRefreshNee
             .filter(Boolean)
             .join(', ')}`
         );
+      } else {
+        // Clear warning if no errors for this lens
+        setShowPartialResultsWarning(false);
+        setPartialResultsError('');
       }
 
       setActiveWorkItem(loadedWorkItem);


### PR DESCRIPTION
## Summary
Fixes #40 - Resolves the issue where "Partial Analysis Results" warning and error messages incorrectly persist when switching from a work item with errors to another work item without errors.

## Problem
When users switch between work items in the "My Work Items" panel:
Select a work item with "Partial Analysis Results" → warning appears (correct)
Switch to a different work item with no errors → warning still appears (incorrect)
The same issue occurs with "Failed to retrieve risk summary" error messages
This misleads users about the actual status of the current analysis.

## Root Cause
In `handleWorkItemSelect` function, warning states were only set to `true` when errors existed
No explicit clearing of warning states when switching to error-free work items
General error state was not reset when switching work items

## Solution
### 1. Enhanced State Reset on Work Item Switch
Reset `showPartialResultsWarning`, `partialResultsError`, and general `error` state when switching work items
Updated comment from "Reset risk summary when switching work items" to "Reset states when switching work items"

### 2. Explicit Warning State Management
Added `else` clause to explicitly clear warnings when no errors exist for the current lens
Ensures UI accurately reflects the current work item's status

## Testing Steps
Create or use a work item with analysis errors (shows "Partial Analysis Results" warning)
Load the results for this work item → verify warning appears
Switch to a different work item without errors
Load the results for the new work item → verify warning is cleared

Before : #40 
After : https://github.com/user-attachments/assets/6a48191b-e963-43cb-ace5-d9dc2ba1b501

