### PR TITLE
Fix 40: Properly updating any partial-results-related attributes when…

### DIFF
--- a/ecs_fargate_app/backend/src/modules/analyzer/analyzer.service.ts
+++ b/ecs_fargate_app/backend/src/modules/analyzer/analyzer.service.ts
@@ -907,6 +907,12 @@ export class AnalyzerService {
             const completeAnalysisProgressMap = { ...(workItem.analysisProgress || {}) };
             completeAnalysisProgressMap[currentLensAlias] = 100;
 
+            const completeAnalysisErrorMap = { ...(workItem.analysisError || {}) };
+            completeAnalysisErrorMap[currentLensAlias] = ''; // Set clear error message on successful completion
+
+            const completeAnalysisPartialResultsMap = { ...(workItem.analysisPartialResults || {}) };
+            completeAnalysisPartialResultsMap[currentLensAlias] = false;
+
             // Store final results for this lens
             await this.storageService.storeAnalysisResults(
                 userId,
@@ -918,6 +924,8 @@ export class AnalyzerService {
             await this.storageService.updateWorkItem(userId, fileId, {
                 analysisStatus: completeAnalysisStatusMap,
                 analysisProgress: completeAnalysisProgressMap,
+                analysisError: completeAnalysisErrorMap,
+                analysisPartialResults: completeAnalysisPartialResultsMap,
                 lastModified: new Date().toISOString(),
             });
 
@@ -1197,9 +1205,17 @@ export class AnalyzerService {
             finalIacGenerationStatusMap[currentLensAlias] = 'COMPLETED';
             finalIacGenerationProgressMap[currentLensAlias] = 100;
 
+            const finalIacGenerationErrorMap = { ...(workItem.iacGenerationError || {}) };
+            finalIacGenerationErrorMap[currentLensAlias] = ''; // Set clear error message on successful completion
+
+            const finalIacPartialResultsMap = { ...(workItem.iacPartialResults || {}) };
+            finalIacPartialResultsMap[currentLensAlias] = false;
+
             await this.storageService.updateWorkItem(userId, fileId, {
                 iacGenerationStatus: finalIacGenerationStatusMap,
                 iacGenerationProgress: finalIacGenerationProgressMap,
+                iacGenerationError: finalIacGenerationErrorMap,
+                iacPartialResults: finalIacPartialResultsMap,
                 lastModified: new Date().toISOString(),
             });
 


### PR DESCRIPTION
*Issue #, if available:* #40

*Description of changes:* Changes to backend `analyzer.service.ts` component so that it properly update any partial-results-related attributes when a subsequent analysis is completed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
