### PR TITLE
fix: correct parameter container_insights_v2

### DIFF
--- a/ecs_fargate_app/wa_genai_stack.py
+++ b/ecs_fargate_app/wa_genai_stack.py
@@ -779,7 +779,7 @@ class WAGenAIStack(Stack):
         public_subnets = vpc.select_subnets(subnet_type=ec2.SubnetType.PUBLIC)
 
         # Create ECS Cluster
-        ecs_cluster = ecs.Cluster(self, "AppCluster", vpc=vpc, container_insights=ecs.ContainerInsights.ENABLED)
+        ecs_cluster = ecs.Cluster(self, "AppCluster", vpc=vpc, container_insights_v2=ecs.ContainerInsights.ENABLED)
 
         # Add ECS Service Discovery namespace
         namespace = servicediscovery.PrivateDnsNamespace(


### PR DESCRIPTION
…ABLED as shown in the AWS documentation example. This should resolve both the deprecation warning and the type error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
