### PR TITLE
Add support for Claude Opus 4.8 and Fable 5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Additionally, an **interactive Analyzer Assistant chatbot** enables users to ask
   - Default adjustable batch size configuration (between 1-12) balances speed and API throttling risk
 
 - **NEW** 🧠 **Enhanced AI Capabilities with Latest Anthropic Models:**
-  - Full support for **Claude Opus 4.7**, **Claude Sonnet 4.6**, and **Claude Opus 4.6** models
-  - **Claude 4.6+ models** leverage **Adaptive Thinking** for complex reasoning and analysis
-  - **1M token context window** natively supported by Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6 models, enabling analysis of much larger IaC projects and architectural documentation in a single pass
+  - Full support for **Claude Fable 5**, **Claude Opus 4.8**, **Claude Opus 4.7**, **Claude Sonnet 4.6**, and **Claude Opus 4.6** models
+  - **Supported Claude models** leverage **Adaptive Thinking** for complex reasoning and analysis
+  - **1M token context window** natively supported by Claude Fable 5, Claude Opus 4.8, Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6 models, enabling analysis of much larger IaC projects and architectural documentation in a single pass
 
 - **NEW** 💰 **Cost-Optimized Vector Storage with Amazon S3 Vectors:**
   - **S3 Vectors** is now the default vector store for the Bedrock Knowledge Base
@@ -141,7 +141,7 @@ This option uses AWS CloudFormation to create a temporary deployment environment
 
      - **Security Note:** By default, the stack deploys with a Public Application Load Balancer (internet-facing) with authentication enabled. For maximum security, we strongly recommend keeping authentication enabled for internet-facing deployments. If you disable authentication, your application will be publicly accessible without any security controls.
 
-     - **Model Selection Note:** The tool currently defaults to **Claude Sonnet 4.6**. If you want to use a different model (E.g. Claude Opus 4.7 or Claude Opus 4.6), you'll need to explicitly add the model ID in the stack "Amazon Bedrock Model ID" configuration parameter. Please note that not all models are available in all AWS regions, so verify availability in your region before deployment.
+     - **Model Selection Note:** The tool currently defaults to **Claude Sonnet 4.6**. If you want to use a different model (E.g. Claude Fable 5, Claude Opus 4.8, or Claude Opus 4.7), you'll need to explicitly add the model ID in the stack "Amazon Bedrock Model ID" configuration parameter. Please note that not all models are available in all AWS regions, so verify availability in your region before deployment.
   
      - **Geographic and Global Cross-Region Inference Note:** The default Claude Sonnet 4.6 model ID uses a GLOBAL cross-Region inference profile (`global.anthropic.claude-sonnet-4-6`), which routes requests to any supported AWS commercial Region worldwide for optimal performance and cost savings. If your organization has data residency or compliance requirements, consider using a GEOGRAPHIC inference profile instead (e.g., "us." or "eu." prefix). For more information visit the documentation [Choosing between Geographic and Global cross-Region inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html#cross-region-inference-comparison)
 
@@ -350,8 +350,9 @@ After successful deployment, you can find the Application Load Balancer (ALB) DN
 - **Amazon Bedrock Model ID** (`ModelId`)
   - Default: `global.anthropic.claude-sonnet-4-6` (Claude Sonnet 4.6)
   - You can specify an alternative [Bedrock model ID](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns) if needed
-  - **Note**: This application has been primarily tested with Anthropic models (Claude Opus 4.7, Claude Sonnet 4.6, Claude Opus 4.6, Claude Sonnet 4.5, and Claude Opus 4.5). While other Bedrock models may work, using different models might lead to unexpected results.
-  - **Claude 4.7 models**: Use Adaptive Thinking with xhigh effort for complex reasoning and analysis. Natively support 1M token context window.
+  - **Note**: This application has been primarily tested with Anthropic models (Claude Fable 5, Claude Opus 4.8, Claude Opus 4.7, Claude Sonnet 4.6, Claude Opus 4.6, Claude Sonnet 4.5, and Claude Opus 4.5). While other Bedrock models may work, using different models might lead to unexpected results.
+  - **Claude Fable 5**: Uses always-on Adaptive Thinking (no thinking configuration is sent) with high effort. Natively supports 1M token context window.
+  - **Claude Opus 4.8 / 4.7 models**: Use Adaptive Thinking with xhigh effort for complex reasoning and analysis. Natively support 1M token context window.
   - **Claude 4.6 models**: Use Adaptive Thinking with high effort for complex reasoning and analysis. Natively support 1M token context window.
   - **Claude 4.5 models**: Use Extended Thinking with budget tokens for enhanced analysis.
 
@@ -468,7 +469,7 @@ If you want to use a different model than the default Claude Sonnet 4.6, update 
 model_id = global.anthropic.claude-sonnet-4-6
 ```
 
-> **Note:** This application has been primarily tested with Anthropic models (Claude Opus 4.7, Claude Sonnet 4.6, Claude Opus 4.6, Claude Sonnet 4.5, and Claude Opus 4.5). While other Bedrock models may work, using different models might lead to unexpected results. The default model ID is set to `global.anthropic.claude-sonnet-4-6`. Claude 4.7 models use Adaptive Thinking with xhigh effort and natively support 1M token context window. Claude 4.6 models use Adaptive Thinking with high effort and natively support 1M token context window, while Claude 4.5 models use Extended Thinking with budget tokens.
+> **Note:** This application has been primarily tested with Anthropic models (Claude Fable 5, Claude Opus 4.8, Claude Opus 4.7, Claude Sonnet 4.6, Claude Opus 4.6, Claude Sonnet 4.5, and Claude Opus 4.5). While other Bedrock models may work, using different models might lead to unexpected results. The default model ID is set to `global.anthropic.claude-sonnet-4-6`. Claude Fable 5 uses always-on Adaptive Thinking with high effort and natively supports a 1M token context window. Claude Opus 4.8 and 4.7 models use Adaptive Thinking with xhigh effort and natively support 1M token context window. Claude 4.6 models use Adaptive Thinking with high effort and natively support 1M token context window, while Claude 4.5 models use Extended Thinking with budget tokens.
 
 ### Batch Size Configuration
 

--- a/cfn_deployment_stacks/iac-analyzer-deployment-stack.yaml
+++ b/cfn_deployment_stacks/iac-analyzer-deployment-stack.yaml
@@ -12,7 +12,7 @@ Parameters:
   ModelId:
     Type: String
     Default: 'global.anthropic.claude-sonnet-4-6'
-    Description: 'Amazon Bedrock Model ID to use for analysis. By default uses Claude Sonnet 4.6. The default model uses a GLOBAL cross-Region inference profile, which routes requests to any supported AWS commercial Region worldwide for optimal performance and cost savings. If your organization has data residency or compliance requirements, consider using a GEOGRAPHIC inference profile instead (e.g., "us." or "eu." prefix).'
+    Description: 'Amazon Bedrock Model ID to use for analysis. By default uses Claude Sonnet 4.6. You can also use newer models such as Claude Fable 5 (global.anthropic.claude-fable-5) or Claude Opus 4.8 (global.anthropic.claude-opus-4-8). The default model uses a GLOBAL cross-Region inference profile, which routes requests to any supported AWS commercial Region worldwide for optimal performance and cost savings. If your organization has data residency or compliance requirements, consider using a GEOGRAPHIC inference profile instead (e.g., "us." or "eu." prefix).'
   
   BatchSize:
     Type: Number

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,7 @@
 [settings]
 model_id = global.anthropic.claude-sonnet-4-6
 # [ model_id NOTE ]
+# The default model is Claude Sonnet 4.6. You can also use newer models such as Claude Fable 5 (global.anthropic.claude-fable-5) or Claude Opus 4.8 (global.anthropic.claude-opus-4-8).
 # The default model uses a GLOBAL cross-Region inference profile, which routes requests to any supported AWS commercial Region worldwide for optimal performance and cost savings. If your organization has data residency or compliance requirements, consider using a GEOGRAPHIC inference profile instead (e.g., "us." or "eu." prefix). For more information: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html#cross-region-inference-comparison
 
 # Batch Size Configuration for Analysis Processing

--- a/ecs_fargate_app/backend/src/modules/analyzer/analyzer.service.ts
+++ b/ecs_fargate_app/backend/src/modules/analyzer/analyzer.service.ts
@@ -342,6 +342,25 @@ export class AnalyzerService {
         return modelId.includes('claude-opus-4-7');
     }
 
+    // Check if the current model is Claude Opus 4.8.
+    // Behaves like Opus 4.7 at the API level: adaptive thinking, no budget_tokens,
+    // no sampling params, native 1M context window (no beta header needed), supports xhigh effort.
+    private isOpus48(): boolean {
+        const modelId = this.configService.get<string>('aws.bedrock.modelId');
+        if (!modelId) return false;
+        return modelId.includes('claude-opus-4-8');
+    }
+
+    // Check if the current model is Claude Fable 5.
+    // Adaptive thinking is ALWAYS ON (no thinking field must be sent, and
+    // thinking: {type: "disabled"} returns an error). No budget_tokens, no sampling
+    // params, native 1M context window. Effort defaults to "high".
+    private isFable5(): boolean {
+        const modelId = this.configService.get<string>('aws.bedrock.modelId');
+        if (!modelId) return false;
+        return modelId.includes('claude-fable-5');
+    }
+
     /**
      * Extracts and concatenates all text content from a Bedrock response content array.
      * @param content The content array from Bedrock response
@@ -364,9 +383,27 @@ export class AnalyzerService {
         const useExtendedThinking = this.supportsExtendedThinking();
         const extendedContextWindow = this.configService.get<boolean>('aws.bedrock.extendedContextWindow', false);
 
-        // Claude Opus 4.7: Adaptive thinking only, no budget_tokens, no sampling params,
-        // native 1M context window (no beta header needed), supports xhigh effort
-        if (this.isOpus47()) {
+        // Claude Fable 5: Adaptive thinking is ALWAYS ON, so the "thinking" field
+        // must NOT be sent (thinking: {type: "disabled"} returns an error, and requests
+        // without a thinking field already run with adaptive thinking). No budget_tokens,
+        // no sampling params, native 1M context window. Effort defaults to "high" (lower
+        // effort levels on Fable 5 already exceed xhigh performance on prior models).
+        if (this.isFable5()) {
+            return {
+                additionalModelRequestFields: {
+                    output_config: {
+                        effort: "high"
+                    }
+                },
+                inferenceConfig: {
+                    maxTokens: 32000
+                }
+            };
+        }
+
+        // Claude Opus 4.7 and Opus 4.8: Adaptive thinking only, no budget_tokens,
+        // no sampling params, native 1M context window (no beta header needed), supports xhigh effort
+        if (this.isOpus47() || this.isOpus48()) {
             return {
                 additionalModelRequestFields: {
                     thinking: {
@@ -2092,6 +2129,8 @@ export class AnalyzerService {
         // (or require custom prompt templates).
         const unsupportedKbModels = [
             'claude-opus-4-7',
+            'claude-opus-4-8',
+            'claude-fable-5',
         ];
 
         const isUnsupported = unsupportedKbModels.some(m => configuredModelId.includes(m));
@@ -2114,10 +2153,10 @@ export class AnalyzerService {
      */
     private kbModelForbidsSamplingParams(): boolean {
         const configuredModelId = this.configService.get<string>('aws.bedrock.modelId');
-        // Claude Opus 4.7 rejects non-default temperature/top_p/top_k.
+        // Claude Opus 4.7, Opus 4.8 and Fable 5 reject non-default temperature/top_p/top_k.
         // The fallback model (Sonnet 4.6) also uses adaptive thinking and
         // may reject these, so we check the *effective* KB model too.
-        const modelsWithoutSampling = ['claude-opus-4-7'];
+        const modelsWithoutSampling = ['claude-opus-4-7', 'claude-opus-4-8', 'claude-fable-5'];
         return modelsWithoutSampling.some(m => configuredModelId.includes(m));
     }
 

--- a/ecs_fargate_app/backend/src/prompts/system-prompts.ts
+++ b/ecs_fargate_app/backend/src/prompts/system-prompts.ts
@@ -12,6 +12,8 @@ function supportsExtendedThinking(modelId?: string): boolean {
   
   return [
     'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-fable-5',
     'claude-3-7-sonnet',
     'claude-haiku-4-5',
     'claude-sonnet-4-5',


### PR DESCRIPTION
*Description of changes:*

Add support for Claude Opus 4.8 and Fable 5 models.

Handle adaptive-thinking params, KB fallback, and sampling rules for the new models while keeping Sonnet 4.6 as the default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
