### PR TITLE
Fix upside-down Priorities matrix Y-axis label for Japanese and Korean

### DIFF
--- a/ecs_fargate_app/frontend/src/components/PrioritiesView.css
+++ b/ecs_fargate_app/frontend/src/components/PrioritiesView.css
@@ -44,6 +44,18 @@
   white-space: nowrap;
 }
 
+/* CJK languages (ja, ko) render glyphs upright in vertical-rl mode, so the
+   180deg rotation used for Latin scripts would flip them upside down. */
+.priority-matrix-yaxis-label--cjk {
+  writing-mode: vertical-rl;
+  transform: none;
+  font-size: 13px;
+  font-weight: 700;
+  color: #414d5c;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
 .priority-matrix-axis-end {
   font-size: 12px;
   color: #5f6b7a;

--- a/ecs_fargate_app/frontend/src/components/PrioritiesView.tsx
+++ b/ecs_fargate_app/frontend/src/components/PrioritiesView.tsx
@@ -352,6 +352,11 @@ const PriorityPlot: React.FC<PriorityPlotProps> = ({
   localizePriority,
   localizeLevel,
 }) => {
+  const { language } = useLanguage();
+  // CJK scripts (Japanese, Korean) render upright in vertical writing mode and
+  // must not be rotated 180deg, which would otherwise flip them upside down.
+  const isCjkLanguage = language === 'ja' || language === 'ko';
+
   const quadrantCounts: Record<QuadrantId, number> = {
     'quick-wins': 0,
     'major-initiatives': 0,
@@ -369,7 +374,9 @@ const PriorityPlot: React.FC<PriorityPlotProps> = ({
       {/* Y axis */}
       <div className="priority-matrix-yaxis">
         <span className="priority-matrix-axis-end">{axisStrings.high}</span>
-        <span className="priority-matrix-yaxis-label">{axisStrings.impact}</span>
+        <span className={isCjkLanguage ? 'priority-matrix-yaxis-label--cjk' : 'priority-matrix-yaxis-label'}>
+          {axisStrings.impact}
+        </span>
         <span className="priority-matrix-axis-end">{axisStrings.low}</span>
       </div>
 


### PR DESCRIPTION
*Issue #, if available:* #166

*Description of changes:*
Fix upside-down Priorities matrix Y-axis label for Japanese and Korean by skipping the 180 rotation for CJK languages


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
